### PR TITLE
Remove goblintown.wtf from allowed collateral

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,5 @@ Feel free to open a pull request: suggesting a change to the allowlist, in-consi
 | Loot                      | 0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7 | 2023-02-09 |
 | Lil Pudgys                | 0x524cab2ec69124574082676e6f654a18df49a048 | 2023-03-02 |
 | MoonCats                  | 0xc3f733ca98e0dad0386979eb96fb1722a1a05e69 | 2023-03-02 |
-| goblintown.wtf            | 0xbce3781ae7ca1a5e050bd9c4c77369867ebc307e | 2023-03-02 |
 | Sappy Seals               | 0x364c828ee171616a39897688a831c2499ad972ec | 2023-03-02 |
 | Chimpers                  | 0x80336ad7a747236ef41f47ed2c7641828a480baa | 2023-03-02 |


### PR DESCRIPTION
Goblins recently updated their art, such that all NFTs now render the same image that is unrelated to the prior project art. https://opensea.io/collection/goblintownwtf

Additionally, the bid depth has thinned considerably, with now only 1 bid above 50% of the top collection bid price (i.e. the top collection bid). There are currently no goblin loans and we should remove the collection as allowed collateral to guard risk of liquidation shortfall. 