### PR TITLE
Remove unused collateral from allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,11 @@ Feel free to open a pull request: suggesting a change to the allowlist, in-consi
 ### Allowlisted Collections
 | Name                      | Contract                                   | Date Added |
 |---------------------------|--------------------------------------------|------------|
-| Cool Cats                 | 0x1a92f7381b9f03921564a437210bb9396471050c | 2023-02-09 |
 | Cryptoadz                 | 0x1cb1a5e65610aeff2551a50f76a87a7d3fb649c6 | 2023-02-09 |
 | Beanz                     | 0x306b1ea3ecdf94ab739f1910bbda052ed4a9f949 | 2023-02-09 |
-| CryptoDickbutts S3        | 0x42069abfe407c60cf4ae4112bedead391dba1cdb | 2023-02-09 |
 | ForgottenRunesWizardsCult | 0x521f9c7505005cfa19a8e5786a9c3c9c9f5e6f42 | 2023-02-09 |
 | Milady                    | 0x5af0d9827e0c53e4799bb226655a1de152a425a5 | 2023-02-09 |
 | mfer                      | 0x79fcdef22feed20eddacbb2587640e45491b757f | 2023-02-09 |
 | PudgyPenguins             | 0xbd3531da5cf5857e7cfaa92426877b022e612cf8 | 2023-02-09 |
 | Tubby Cats                | 0xca7ca7bcc765f77339be2d648ba53ce9c8a262bd | 2023-02-09 |
 | Loot                      | 0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7 | 2023-02-09 |
-| Lil Pudgys                | 0x524cab2ec69124574082676e6f654a18df49a048 | 2023-03-02 |
-| MoonCats                  | 0xc3f733ca98e0dad0386979eb96fb1722a1a05e69 | 2023-03-02 |
-| Sappy Seals               | 0x364c828ee171616a39897688a831c2499ad972ec | 2023-03-02 |
-| Chimpers                  | 0x80336ad7a747236ef41f47ed2c7641828a480baa | 2023-03-02 |
-| Wassies by Wassies        | 0x1d20a51f088492a0f1c57f047a9e30c9ab5c07ea | 2023-04-20 |
-| Moonbirds                 | 0x23581767a106ae21c074b2276d25e5c3e136a68b | 2023-04-20 |
-| Finiliar                  | 0x5a0121a0a21232ec0d024dab9017314509026480 | 2023-04-20 |
-| World of Women            | 0xe785e82358879f061bc3dcac6f0444462d4b5330 | 2023-04-20 |
-| Art Gobblers              | 0x60bb1e2aa1c9acafb4d34f71585d7e959f387769 | 2023-04-20 |
-| Froggy Friends Official   | 0x29652c2e9d3656434bc8133c69258c8d05290f41 | 2023-04-20 |
-| Regulars                  | 0x6d0de90cdc47047982238fcf69944555d27ecb25 | 2023-04-20 |
-| DeGods                    | 0x8821bee2ba0df28761afff119d66390d594cd280 | 2023-04-20 |
-| Moonbirds Oddities        | 0x1792a96e5668ad7c167ab804a100ce42395ce54d | 2023-04-20 |
-| Pixelmon - Generation 1   | 0x32973908faee0bf825a343000fe412ebe56f802a | 2023-04-20 |


### PR DESCRIPTION
Move to a permanent, immutable allowlist, and first remove collateral that has not had borrow demand.